### PR TITLE
Clarify text for "About" link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -26,7 +26,7 @@
         <li class="dropdown">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">What <span class="caret"></span></a>
           <ul class="dropdown-menu">
-            <li><a href="{{site.baseurl}}/about/">About us</a></li>
+            <li><a href="{{site.baseurl}}/about/">About AnthillHacks</a></li>
             <li><a href="{{site.baseurl}}/history/">History</a></li>
           </ul>
         </li>


### PR DESCRIPTION
I associate "About us" with introducing the team behind something - that it led to a page titled "About AnthillHacks" was a surprise.